### PR TITLE
Add filter rendering and improve lever's state management

### DIFF
--- a/app/assets/scripts/components/NavGlobalMenu.js
+++ b/app/assets/scripts/components/NavGlobalMenu.js
@@ -8,7 +8,7 @@ import { environment } from '../config';
 
 const isExplorerActive = (match, location) => {
   return location.pathname.match(/^\/(explore|countries)/g);
-}
+};
 
 export default class NavGlobalMenu extends Component {
   renderHeaderMenu () {

--- a/app/assets/scripts/components/explore/dashboard/Filters.js
+++ b/app/assets/scripts/components/explore/dashboard/Filters.js
@@ -41,7 +41,7 @@ class Filters extends Component {
           filter.options.map((option, i) => {
             return (
               <label
-                key={`${filter.id}-${i}`}
+                key={option.id}
                 className='form__option form__option--custom-radio'
               >
                 <input

--- a/app/assets/scripts/components/explore/dashboard/Filters.js
+++ b/app/assets/scripts/components/explore/dashboard/Filters.js
@@ -1,55 +1,89 @@
 import React, { Component } from 'react';
+import { PropTypes as T } from 'prop-types';
 import InputRange from 'react-input-range';
+
+import { environment } from '../../../config';
 
 import ShadowScrollbars from '../../ShadowScrollbar';
 
 class Filters extends Component {
+  constructor (props) {
+    super(props);
+
+    this.renderRangeFilter = this.renderRangeFilter.bind(this);
+  }
+
+  renderRangeFilter (filter) {
+    const filterState = this.props.filtersState[filter.id];
+    const { min, max } = filter.range;
+
+    return (
+      <div className='form__group econtrols__item' key={`${filter.id}`}>
+        <label htmlFor='slider-1' className='form__label'>
+          {filter.label}
+        </label>
+        <InputRange
+          minValue={min}
+          maxValue={max}
+          value={filterState}
+          onChange={this.props.handleFilterChange.bind(this, filter.id)}
+        />
+      </div>
+    );
+  }
+
+  renderOptionsFilter (filter) {
+    const filterState = this.props.filtersState[filter.id];
+    return (
+      <div className='form__group econtrols__item' key={`${filter.id}`}>
+        <label className='form__label'>{filter.label}</label>
+        {filter.options &&
+          filter.options.map((option, i) => {
+            return (
+              <label
+                key={`${filter.id}-${i}`}
+                className='form__option form__option--custom-radio'
+              >
+                <input
+                  type='radio'
+                  name={`form-radio-${filter.id}`}
+                  id={`form-radio-${i}`}
+                  value={i}
+                  checked={filterState === i}
+                  onChange={this.props.handleFilterChange.bind(
+                    this,
+                    filter.id,
+                    i
+                  )}
+                />
+                <span className='form__option__ui' />
+                <span className='form__option__text'>
+                  {option.label || option.value}
+                </span>
+              </label>
+            );
+          })}
+      </div>
+    );
+  }
+
+  renderFilters (filters) {
+    return filters.map(filter => {
+      if (filter.type === 'range') return this.renderRangeFilter(filter);
+      else return this.renderOptionsFilter(filter);
+    });
+  }
+
   render () {
+    const { filters } = this.props;
+
     return (
       <section className='econtrols__section' id='econtrols-filters'>
         <h1 className='econtrols__title'>Filters</h1>
         <form className='form econtrols__block' id='#econtrols__scenarios'>
           <div className='econtrols__subblock'>
             <ShadowScrollbars theme='light'>
-              <div className='form__group econtrols__item'>
-                <label htmlFor='slider-1' className='form__label'>Population</label>
-                <InputRange maxValue={20} minValue={0} value={10} />
-              </div>
-              <div className='form__group econtrols__item'>
-                <label className='form__label'>
-                  Electrification Technology
-                </label>
-                <label className='form__option form__option--custom-radio'>
-                  <input
-                    type='radio'
-                    name='form-radio-b'
-                    id='form-radio-1'
-                    value='Grid'
-                  />
-                  <span className='form__option__ui' />
-                  <span className='form__option__text'>Grid</span>
-                </label>
-                <label className='form__option form__option--custom-radio'>
-                  <input
-                    type='radio'
-                    name='form-radio-b'
-                    id='form-radio-2'
-                    value='PV MG'
-                  />
-                  <span className='form__option__ui' />
-                  <span className='form__option__text'>PV MG</span>
-                </label>
-                <label className='form__option form__option--custom-radio'>
-                  <input
-                    type='radio'
-                    name='form-radio-b'
-                    id='form-radio-3'
-                    value='PV SA'
-                  />
-                  <span className='form__option__ui' />
-                  <span className='form__option__text'>PV SA</span>
-                </label>
-              </div>
+              {filters && filters.length > 0 && this.renderFilters(filters)}
             </ShadowScrollbars>
           </div>
           <div className='form__actions econtrols__actions'>
@@ -61,6 +95,14 @@ class Filters extends Component {
       </section>
     );
   }
+}
+
+if (environment !== 'production') {
+  Filters.propTypes = {
+    filters: T.array,
+    filtersState: T.array,
+    handleFilterChange: T.func
+  };
 }
 
 export default Filters;

--- a/app/assets/scripts/components/explore/dashboard/Levers.js
+++ b/app/assets/scripts/components/explore/dashboard/Levers.js
@@ -5,39 +5,25 @@ import { environment } from '../../../config';
 
 import ShadowScrollbars from '../../ShadowScrollbar';
 
-function makeZeroFilledArray (length) {
-  return Array.apply(null, {
-    length
-  }).map(() => 0);
-}
-
 class Levers extends Component {
   constructor (props) {
     super(props);
 
     this.renderLever = this.renderLever.bind(this);
-    this.handleLeverChange = this.handleLeverChange.bind(this);
-    this.state = {
-      scenario: makeZeroFilledArray(props.model.levers.length)
-    };
+    this.applyLevers = this.applyLevers.bind(this);
   }
 
   componentDidMount () {
-    this.props.updateScenario(this.state.scenario.join('_'));
+    this.applyLevers();
   }
 
-  handleLeverChange (leverId, optionIndex) {
-    const { scenario } = this.state;
-    scenario[leverId] = optionIndex;
-
-    this.setState({
-      scenario
-    });
+  applyLevers () {
+    this.props.updateScenario(this.props.leversState.join('_'));
   }
 
   renderLever (lever) {
-    const { scenario } = this.state;
-    const checkedOption = scenario[lever.id] ? scenario[lever.id] : 0;
+    const { leversState } = this.props;
+    const checkedOption = leversState[lever.id];
 
     return (
       <div className='form__group econtrols__item' key={`${lever.id}`}>
@@ -54,7 +40,7 @@ class Levers extends Component {
                 id={`form-radio-${i}`}
                 value={i}
                 checked={checkedOption === i}
-                onChange={this.handleLeverChange.bind(this, lever.id, i)}
+                onChange={this.props.handleLeverChange.bind(this, lever.id, i)}
               />
               <span className='form__option__ui' />
               <span className='form__option__text'>{option.value}</span>
@@ -66,14 +52,14 @@ class Levers extends Component {
   }
 
   render () {
-    const { model } = this.props;
+    const { levers } = this.props;
     return (
       <section className='econtrols__section' id='econtrols-scenarios'>
         <h1 className='econtrols__title'>Scenarios</h1>
         <form className='form econtrols__block' id='#econtrols__scenarios'>
           <div className='econtrols__subblock'>
             <ShadowScrollbars theme='light'>
-              {model.levers.map(this.renderLever)}
+              {levers.map(this.renderLever)}
             </ShadowScrollbars>
           </div>
           <div className='form__actions econtrols__actions'>
@@ -83,7 +69,7 @@ class Levers extends Component {
               title='Apply'
               onClick={e => {
                 e.preventDefault();
-                this.props.updateScenario(this.state.scenario.join('_'));
+                this.applyLevers();
               }}
             >
               <span>Apply changes</span>
@@ -97,8 +83,10 @@ class Levers extends Component {
 
 if (environment !== 'production') {
   Levers.propTypes = {
-    updateScenario: T.func,
-    model: T.object
+    levers: T.array,
+    leversState: T.array,
+    handleLeverChange: T.func,
+    updateScenario: T.func
   };
 }
 

--- a/app/assets/scripts/components/explore/dashboard/Levers.js
+++ b/app/assets/scripts/components/explore/dashboard/Levers.js
@@ -1,9 +1,9 @@
 import React, { Component } from 'react';
 import { PropTypes as T } from 'prop-types';
 
-import ShadowScrollbars from '../../ShadowScrollbar';
-
 import { environment } from '../../../config';
+
+import ShadowScrollbars from '../../ShadowScrollbar';
 
 function makeZeroFilledArray (length) {
   return Array.apply(null, {

--- a/app/assets/scripts/components/explore/dashboard/index.js
+++ b/app/assets/scripts/components/explore/dashboard/index.js
@@ -11,10 +11,34 @@ class Dashboard extends Component {
   constructor (props) {
     super(props);
 
+    this.handleFilterChange = this.handleFilterChange.bind(this);
+
     this.state = {
-      activeTab: 'scenarios'
+      activeTab: 'scenarios',
+      filtersState: props.model.filters
+        ? props.model.filters.map(filter => {
+          if (filter.type === 'range') {
+            return filter.range;
+          } else return 0;
+        })
+        : []
     };
     this.renderTabs = this.renderTabs.bind(this);
+  }
+
+  handleFilterChange (i, value) {
+    const { filtersState } = this.state;
+    const filter = this.props.model.filters[i];
+
+    // Ensure that range values are between min and max
+    if (filter.type === 'range') {
+      const { min, max } = filter.range;
+      if (value.min < min) value.min = min;
+      else if (value.max > max) value.max = max;
+    }
+
+    filtersState[i] = value;
+    this.setState({ filtersState });
   }
 
   renderTabs () {
@@ -43,10 +67,22 @@ class Dashboard extends Component {
     const { activeTab } = this.state;
     if (activeTab === 'scenarios') {
       return (
-        <Levers updateScenario={this.props.updateScenario} model={this.props.model} />
+        <Levers
+          updateScenario={this.props.updateScenario}
+          model={this.props.model}
+        />
       );
-    } else if (activeTab === 'filters') return <Filters />;
-    else if (activeTab === 'layers') return <Layers />;
+    } else if (activeTab === 'filters') {
+      const { filters } = this.props.model;
+      const { filtersState } = this.state;
+      return (
+        <Filters
+          filters={filters}
+          filtersState={filtersState}
+          handleFilterChange={this.handleFilterChange}
+        />
+      );
+    } else if (activeTab === 'layers') return <Layers />;
   }
 
   render () {

--- a/app/assets/scripts/components/explore/dashboard/index.js
+++ b/app/assets/scripts/components/explore/dashboard/index.js
@@ -6,12 +6,14 @@ import Levers from './Levers';
 import Filters from './Filters';
 
 import { environment } from '../../../config';
+import { makeZeroFilledArray } from '../../../utils';
 
 class Dashboard extends Component {
   constructor (props) {
     super(props);
 
     this.handleFilterChange = this.handleFilterChange.bind(this);
+    this.handleLeverChange = this.handleLeverChange.bind(this);
 
     this.state = {
       activeTab: 'scenarios',
@@ -21,9 +23,18 @@ class Dashboard extends Component {
             return filter.range;
           } else return 0;
         })
-        : []
+        : [],
+      leversState: makeZeroFilledArray(props.model.levers.length)
     };
     this.renderTabs = this.renderTabs.bind(this);
+  }
+
+  handleLeverChange (leverId, optionId) {
+    const { leversState } = this.state;
+    leversState[leverId] = optionId;
+    this.setState({
+      leversState
+    });
   }
 
   handleFilterChange (i, value) {
@@ -66,10 +77,14 @@ class Dashboard extends Component {
   renderTabContent () {
     const { activeTab } = this.state;
     if (activeTab === 'scenarios') {
+      const { levers } = this.props.model;
+      const { leversState } = this.state;
       return (
         <Levers
+          levers={levers}
+          leversState={leversState}
+          handleLeverChange={this.handleLeverChange}
           updateScenario={this.props.updateScenario}
-          model={this.props.model}
         />
       );
     } else if (activeTab === 'filters') {

--- a/app/assets/scripts/components/explore/dashboard/index.js
+++ b/app/assets/scripts/components/explore/dashboard/index.js
@@ -6,7 +6,7 @@ import Levers from './Levers';
 import Filters from './Filters';
 
 import { environment } from '../../../config';
-import { makeZeroFilledArray } from '../../../utils';
+import { makeZeroFilledArray, cloneArrayAndChangeCell } from '../../../utils';
 
 class Dashboard extends Component {
   constructor (props) {
@@ -30,25 +30,31 @@ class Dashboard extends Component {
   }
 
   handleLeverChange (leverId, optionId) {
-    const { leversState } = this.state;
-    leversState[leverId] = optionId;
+    const leversState = cloneArrayAndChangeCell(
+      this.state.leversState,
+      leverId,
+      optionId
+    );
     this.setState({
       leversState
     });
   }
 
   handleFilterChange (i, value) {
-    const { filtersState } = this.state;
-    const filter = this.props.model.filters[i];
-
     // Ensure that range values are between min and max
+    const filter = this.props.model.filters[i];
     if (filter.type === 'range') {
       const { min, max } = filter.range;
       if (value.min < min) value.min = min;
       else if (value.max > max) value.max = max;
     }
 
-    filtersState[i] = value;
+    const filtersState = cloneArrayAndChangeCell(
+      this.state.filtersState,
+      i,
+      value
+    );
+
     this.setState({ filtersState });
   }
 

--- a/app/assets/scripts/utils.js
+++ b/app/assets/scripts/utils.js
@@ -13,3 +13,14 @@ export function padNumber (value, len = 0) {
   }
   return value;
 }
+
+/**
+ * Make an array where each cell is 0.
+ *
+ * @param {number} length Array length
+ */
+export function makeZeroFilledArray (length) {
+  return Array.apply(null, {
+    length
+  }).map(() => 0);
+}

--- a/app/assets/scripts/utils.js
+++ b/app/assets/scripts/utils.js
@@ -24,3 +24,16 @@ export function makeZeroFilledArray (length) {
     length
   }).map(() => 0);
 }
+
+/**
+ * Clone array and change a cell. Based on this solution:
+ *
+ *  - https://medium.com/@giltayar/immutably-setting-a-value-in-a-js-array-or-how-an-array-is-also-an-object-55337f4d6702
+ *
+ * @param {number} array Source array
+ * @param {number} index Cell index
+ * @param {object} value Cell value
+ */
+export function cloneArrayAndChangeCell (array, index, value) {
+  return Object.assign([...array], { [index]: value });
+}

--- a/app/assets/scripts/views/Home.js
+++ b/app/assets/scripts/views/Home.js
@@ -94,6 +94,7 @@ class Home extends Component {
 
             <figure className='home-media'>
               <div className='home-media__item'>
+                {/* eslint-disable */}
                 <svg id="home-illu" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1440 1024" preserveAspectRatio="xMaxYMin meet">
                   <title>GEP EXP Illustration</title>
                   <rect id="sky" width="1440" height="1024" fill="#474ccc"/>
@@ -289,6 +290,7 @@ class Home extends Component {
                     </g>
                   </g>
                 </svg>
+                {/* eslint-enable */}
               </div>
               <figcaption>Illustration</figcaption>
             </figure>

--- a/app/assets/scripts/views/Home.js
+++ b/app/assets/scripts/views/Home.js
@@ -6,7 +6,7 @@ import { PropTypes as T } from 'prop-types';
 import { wrapApiResult } from '../redux/utils';
 import { fetchStats } from '../redux/actions';
 import { environment } from '../config';
-import { padNumber } from '../utils/string';
+import { padNumber } from '../utils';
 
 import App from './App';
 


### PR DESCRIPTION
This pull request is needed before testing changes on the Explorer:

https://github.com/developmentseed/gep-data-service/pull/12

I've added filter rendering and also updated lever state management so changing tabs doesn't reset selected options. The "Apply changes" button for filters is not implemented yet.