### PR TITLE
Add MB Token to default config

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,18 @@ Clone this repository locally and run:
 
     yarn
 
+### Add Mapbox token
+
+Create file `app/assets/scripts/config/local.js` with your Mapbox API token. Example:
+
+```
+'use strict';
+
+export default {
+  mapboxAccessToken: 'ADD MAPBOX API TOKEN HERE'
+};
+```
+
 ### Development
 
 Start server with live code reload at [http://localhost:9000](http://localhost:9000):

--- a/README.md
+++ b/README.md
@@ -21,15 +21,22 @@ Clone this repository locally and run:
 
     yarn
 
-### Add Mapbox token
+#### Config files
+The config files can be found in `app/assets/scripts/config`. After installing the project, there will be an empty `local.js` that you can use to set the config. This file should not be committed.
 
-Create file `app/assets/scripts/config/local.js` with your Mapbox API token. Example:
+The configuration is overridable by environment variables, expressed between []:
 
+- `appTitle` - Meta information. The app title.
+- `appShortTitle` - Meta information. The short app title.
+- `appDescription` - Meta information. The app description.
+- `dataServiceUrl` - The address for the API. [API]
+- `mapboxAccessToken` - The Mapbox Token to load map tiles from. [MB_TOKEN]
+
+Example:
 ```
-'use strict';
-
-export default {
-  mapboxAccessToken: 'ADD MAPBOX API TOKEN HERE'
+module.exports = {
+  api: 'http://localhost:3000',
+  mbtoken: 'asfd23rlmksjdf023rnnsafd'
 };
 ```
 

--- a/app/assets/scripts/config.js
+++ b/app/assets/scripts/config.js
@@ -31,6 +31,7 @@ if (process.env.DS_ENV === 'staging') {
 }
 
 config.default.mapboxAccessToken = process.env.MB_TOKEN || config.default.mapboxAccessToken;
+config.default.dataServiceUrl = process.env.API || config.default.dataServiceUrl;
 
 // The require doesn't play super well with es6 imports. It creates an internal
 // 'default' property. Export that.

--- a/app/assets/scripts/config/defaults.js
+++ b/app/assets/scripts/config/defaults.js
@@ -7,6 +7,7 @@ export default {
     'A tool to explore least cost electrification strategies around the world.',
   baseUrl: 'http://localhost:9000',
   dataServiceUrl: 'http://localhost:3000',
+  mapboxAccessToken: null,
   techLayers: [
     {
       id: '1',


### PR DESCRIPTION
This is purely to make it easier to figure out how the MB Token needs to be set. The default is `null` and won't work out of the box.